### PR TITLE
fix: add manifest.json, correct install path, document Nix Qt requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,21 @@ set(CMAKE_AUTORCC ON)
 option(BUILD_UI_PLUGIN "Build the IComponent UI plugin for logos-app" OFF)
 option(BUILD_UI_APP    "Build the standalone demo app" OFF)
 option(BUILD_TESTS     "Build unit and e2e tests" ON)
+option(BUILD_WITH_NIX_QT "Use Nix-provided Qt 6.9.2 from logos-app" OFF)
+
+# ---------------------------------------------------------------------------
+# Nix Qt support (logos-app ships Qt 6.9.2 via Nix)
+# ---------------------------------------------------------------------------
+if(BUILD_WITH_NIX_QT)
+    if(DEFINED ENV{NIX_QT_PREFIX})
+        list(INSERT CMAKE_PREFIX_PATH 0 "$ENV{NIX_QT_PREFIX}")
+        message(STATUS "Nix Qt: prepending NIX_QT_PREFIX=$ENV{NIX_QT_PREFIX} to CMAKE_PREFIX_PATH")
+    else()
+        message(FATAL_ERROR
+            "BUILD_WITH_NIX_QT is ON but NIX_QT_PREFIX is not set. "
+            "Export NIX_QT_PREFIX=/nix/store/<hash>-qtbase-6.9.2 before configuring.")
+    endif()
+endif()
 
 set(LOGOS_CPP_SDK_ROOT  "" CACHE PATH "Path to logos-cpp-sdk checkout")
 set(LOGOS_LIBLOGOS_ROOT "" CACHE PATH "Path to logos-liblogos checkout")

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ mkdir -p "$PLUGIN_DIR"
 cp build/ui/plugin/video_hotspot.so "$PLUGIN_DIR/"
 ```
 
-Or use the CMake install target (installs to `~/.local/share/LogosAppNix/plugins/`):
+Or use the CMake install target (installs to `~/.local/share/Logos/LogosAppNix/plugins/`):
 
 ```bash
 cmake --install build --prefix "$HOME/.local"
@@ -163,6 +163,32 @@ See [`demo/FURPS_VERIFICATION.md`](demo/FURPS_VERIFICATION.md) for full FURPS+ s
 ---
 
 ## Quick Start
+
+## Building Against Logos-App Qt (Nix Qt 6.9.2)
+
+logos-app ships its own Qt 6.9.2 via Nix. You **must** build the plugin against
+that exact Qt — system Qt will cause ABI mismatches and link errors.
+
+Use the helper script to build with the Nix-provided Qt:
+
+```bash
+# Edit scripts/build-with-nix-qt.sh and replace <hash> placeholders
+# with the real Nix store hashes from your logos-app wrapper
+bash scripts/build-with-nix-qt.sh
+```
+
+Or configure manually:
+
+```bash
+export NIX_QT_PREFIX="/nix/store/<hash>-qtbase-6.9.2"
+cmake -B build -DBUILD_UI_PLUGIN=ON -DBUILD_WITH_NIX_QT=ON
+cmake --build build --target video_hotspot
+```
+
+To find the correct Nix store hash, inspect the logos-app wrapper script
+(e.g. `cat $(which logos-app)`) and look for the `qtbase-6.9.2` path.
+
+---
 
 ### Prerequisites
 

--- a/scripts/build-with-nix-qt.sh
+++ b/scripts/build-with-nix-qt.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# build-with-nix-qt.sh — Build Video Hotspot against logos-app's Nix Qt 6.9.2
+#
+# logos-app ships its own Qt 6.9.2 via Nix. System Qt will NOT work — ABI and
+# version mismatches cause silent crashes or link errors. You MUST build the
+# plugin against the exact same Qt that logos-app uses.
+#
+# How to find the Nix store paths:
+#   1. Look at the logos-app Nix wrapper script (e.g. `cat $(which logos-app)`)
+#   2. Find the qtbase store path, e.g.:
+#        /nix/store/abc123...-qtbase-6.9.2
+#   3. Replace the <hash> placeholders below with the real hashes.
+#
+# You may need additional Qt module paths (Quick, Widgets, etc.) depending on
+# your Nix profile. Separate multiple paths with semicolons.
+
+set -euo pipefail
+
+# ── Replace <hash> with your actual Nix store hashes ──────────────────────
+NIX_QT_PREFIX="/nix/store/<hash>-qtbase-6.9.2"
+# If you need additional Qt modules, append them separated by semicolons:
+# NIX_QT_PREFIX="/nix/store/<hash>-qtbase-6.9.2;/nix/store/<hash>-qtdeclarative-6.9.2"
+
+export NIX_QT_PREFIX
+
+cmake -B build \
+    -DBUILD_UI_PLUGIN=ON \
+    -DBUILD_WITH_NIX_QT=ON \
+    "$@"
+
+cmake --build build --target video_hotspot
+echo ""
+echo "Plugin built: build/ui/plugin/video_hotspot.so"

--- a/ui/plugin/CMakeLists.txt
+++ b/ui/plugin/CMakeLists.txt
@@ -41,52 +41,41 @@ set_target_properties(video_hotspot PROPERTIES
 )
 
 # ---------------------------------------------------------------------------
-# Optional logos-cpp-sdk linkage
+# SDK linkage — handled entirely by root CMakeLists.txt
 # ---------------------------------------------------------------------------
-
-if(LOGOS_CORE_AVAILABLE)
-    # Find Qt RemoteObjects (required by logos-cpp-sdk)
-    find_package(Qt6 REQUIRED COMPONENTS RemoteObjects)
-
-    # logos-cpp-sdk sources (compiled directly — no pre-built .so needed)
-    target_sources(video_hotspot PRIVATE
-        ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api.cpp
-        ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api_client.cpp
-        ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api_consumer.cpp
-        ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api_provider.cpp
-        ${LOGOS_CPP_SDK_ROOT}/cpp/logos_types.cpp
-        ${LOGOS_CPP_SDK_ROOT}/cpp/token_manager.cpp
-        ${LOGOS_CPP_SDK_ROOT}/cpp/module_proxy.cpp
-    )
-
-    target_include_directories(video_hotspot PRIVATE
-        ${LOGOS_CPP_SDK_ROOT}/cpp
-        ${LOGOS_LIBLOGOS_ROOT}/src/logos_core
-        ${LOGOS_LIBLOGOS_ROOT}/src/common
-    )
-
-    target_link_libraries(video_hotspot PRIVATE Qt6::RemoteObjects)
-
-    target_compile_definitions(video_hotspot PRIVATE LOGOS_CORE_AVAILABLE=1)
-endif()
+# The root CMakeLists.txt detects logos-cpp-sdk and wires LOGOS_CORE_AVAILABLE,
+# SDK headers, logos_sdk_lib, logos_core_lib, and Qt6::RemoteObjects into
+# video_hotspot_core via its PUBLIC interface.
+#
+# video_hotspot inherits all of that automatically via:
+#   target_link_libraries(video_hotspot PRIVATE video_hotspot_core)
+#
+# Do NOT re-add SDK sources via target_sources here — that would cause
+# duplicate symbol linker errors (same .cpp files compiled twice into the
+# final .so: once via logos_sdk_lib and once directly).
+# ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
 # Install
 # ---------------------------------------------------------------------------
 # logos-app plugin directory (non-portable default):
-#   ~/.local/share/LogosAppNix/plugins/video_hotspot/video_hotspot.so
+#   ~/.local/share/Logos/LogosAppNix/plugins/video_hotspot/video_hotspot.so
 # logos-app plugin directory (portable):
 #   ~/.local/share/LogosApp/plugins/video_hotspot/video_hotspot.so
 #
 # Manual install (non-portable):
-#   cmake --install . --prefix ~/.local/share/LogosAppNix
+#   cmake --install . --prefix ~/.local/share/Logos/LogosAppNix
 #
 # Or copy directly:
-#   cp video_hotspot.so ~/.local/share/LogosAppNix/plugins/video_hotspot/
+#   cp video_hotspot.so ~/.local/share/Logos/LogosAppNix/plugins/video_hotspot/
 
 include(GNUInstallDirs)
 
 install(TARGETS video_hotspot
-    LIBRARY DESTINATION share/LogosAppNix/plugins/video_hotspot
-    RUNTIME DESTINATION share/LogosAppNix/plugins/video_hotspot
+    LIBRARY DESTINATION share/Logos/LogosAppNix/plugins/video_hotspot
+    RUNTIME DESTINATION share/Logos/LogosAppNix/plugins/video_hotspot
+)
+
+install(FILES manifest.json
+    DESTINATION share/Logos/LogosAppNix/plugins/video_hotspot
 )

--- a/ui/plugin/manifest.json
+++ b/ui/plugin/manifest.json
@@ -1,0 +1,14 @@
+{
+  "author": "marclawclaw",
+  "category": "media",
+  "dependencies": ["codex", "waku"],
+  "description": "Decentralised video upload, geotagging, and map browsing via Logos stack",
+  "icon": "",
+  "main": {
+    "linux-amd64": "video_hotspot.so"
+  },
+  "manifestVersion": "0.1.0",
+  "name": "video_hotspot",
+  "type": "ui",
+  "version": "0.2.0"
+}


### PR DESCRIPTION
Closes #8
Closes #9
Closes #10

## Changes

### #8 — add `ui/plugin/manifest.json` for logos-app discovery
Added the manifest with correct metadata (`author`, `category`, `dependencies: ["codex", "waku"]`, `version: 0.2.0`). Updated `ui/plugin/CMakeLists.txt` to install it alongside the `.so`.

### #9 — correct plugin install path (`Logos/` org prefix was missing)
Replaced every occurrence of `~/.local/share/LogosAppNix/` → `~/.local/share/Logos/LogosAppNix/` in `README.md` and `ui/plugin/CMakeLists.txt` (install destinations + comments).

### #10 — document Nix Qt 6.9.2 build requirement
Added "Building Against Logos-App Qt (Nix Qt 6.9.2)" section to README. Created `scripts/build-with-nix-qt.sh` with `NIX_QT_PREFIX` usage and `<hash>` placeholders. Added `BUILD_WITH_NIX_QT` CMake option to root `CMakeLists.txt`.

---

## Verified closed issues

| # | Title | Status |
|---|-------|--------|
| #3 | build: missing POSITION_INDEPENDENT_CODE on video_hotspot_core | ✅ **Confirmed fixed** — `set_target_properties(video_hotspot_core PROPERTIES POSITION_INDEPENDENT_CODE ON)` present in root CMakeLists.txt |
| #4 | build: standalone app links wrong target name (video_hotspot_plugin → video_hotspot) | ✅ **Confirmed fixed** — `ui/app/CMakeLists.txt` correctly uses `video_hotspot` |
| #5 | build: missing logos_types.cpp in plugin SDK sources | ⚠️ **Re-fixed** — `logos_types.cpp` was added to the old `target_sources` block in the plugin, but that block was itself made redundant by the issue #6 fix (root-level SDK propagation via `logos_sdk_lib PUBLIC`). Having both caused **duplicate symbol linker errors** (SDK compiled twice into `video_hotspot.so`). This PR removes the stale `target_sources` block from `ui/plugin/CMakeLists.txt` entirely — the plugin inherits SDK symbols correctly via `video_hotspot_core PUBLIC`. |
| #6 | build: LOGOS_CORE_AVAILABLE leaks from plugin to CLI, breaking CLI build | ⚠️ **Re-fixed** — the architectural fix (propagate via root CMakeLists.txt) was correct, but the old plugin-level `if(LOGOS_CORE_AVAILABLE) target_sources ...` block was never removed. That stale block duplicated every SDK symbol and would have re-broken the build. Removed in this PR. |
| #7 | docs: README missing Qt6 RemoteObjects and logos-app install instructions | ✅ **Confirmed fixed** — README lists RemoteObjects as a prerequisite (BUILD_UI_PLUGIN only) and links to `logos-co/logos-app` build docs. |